### PR TITLE
Fix decimal number issues for different cultures

### DIFF
--- a/Assets/Scripts/Types/GameSharedResources/AreaTriggerEntityData.cs
+++ b/Assets/Scripts/Types/GameSharedResources/AreaTriggerEntityData.cs
@@ -1,6 +1,8 @@
 ﻿using UnityEngine;
 using System.Collections;
+using System.Globalization;
 using BC2;
+
 public class AreaTriggerEntityData : MonoBehaviour {
 	public bool showSphere = true;
 	GameObject radiusSphere;
@@ -9,7 +11,7 @@ public class AreaTriggerEntityData : MonoBehaviour {
 		showSphere = Util.GetMapload ().showHelpers;
 		Inst inst = transform.GetComponent<BC2Instance> ().instance;
 		string radiusString = Util.GetField ("Radius", inst).value;
-		float radius = float.Parse (radiusString);
+		float radius = float.Parse (radiusString, new CultureInfo("en-US", false));
 		radiusSphere = (GameObject)Instantiate (Util.GetMapload ().sphere, transform.position, transform.rotation);
 		radiusSphere.transform.localScale = new Vector3 (radius, radius, radius);
 		radiusSphere.name = inst.guid + " helper";

--- a/Assets/Scripts/Types/GameSharedResources/TerrainEntityData.cs
+++ b/Assets/Scripts/Types/GameSharedResources/TerrainEntityData.cs
@@ -5,8 +5,8 @@ using System.Diagnostics;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Globalization;
 using BC2;
-
 
 public class TerrainEntityData : MonoBehaviour {
 
@@ -55,7 +55,7 @@ public class TerrainEntityData : MonoBehaviour {
 	int TerrainHeight(string location)
 	{
 		Inst heightFieldData = Util.GetTypes("Terrain.TerrainHeightfieldData", partition)[0];
-		int height = Mathf.CeilToInt(float.Parse(Util.GetField("SizeY", heightFieldData).value));
+		int height = Mathf.CeilToInt(float.Parse(Util.GetField("SizeY", heightFieldData).value, new CultureInfo("en-US", false)));
 		return height;
 	}
 
@@ -65,7 +65,7 @@ public class TerrainEntityData : MonoBehaviour {
 	{
 
 		Inst terrainInst = Util.GetInst(guid, partition);
-		int res = Mathf.CeilToInt(float.Parse(Util.GetField("SizeXZ", terrainInst).value));
+		int res = Mathf.CeilToInt(float.Parse(Util.GetField("SizeXZ", terrainInst).value, new CultureInfo("en-US", false)));
 		return res;
 	}
 

--- a/Assets/Scripts/Types/Physics/HavokAsset.cs
+++ b/Assets/Scripts/Types/Physics/HavokAsset.cs
@@ -4,8 +4,8 @@ using System.Collections.Generic;
 using System;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Globalization;
 using BC2;
-
 
 public class HavokAsset : MonoBehaviour {
     public Partition partition;
@@ -19,7 +19,9 @@ public class HavokAsset : MonoBehaviour {
 
 	private GameObject emptyGO;
 
-	public void Start() {
+    private CultureInfo cultureInfo = new CultureInfo("en-US", false);
+
+    public void Start() {
 		emptyGO = Util.GetMapload ().empty.gameObject;
 
         Inst instance = transform.gameObject.GetComponent<BC2Instance>().instance;
@@ -204,9 +206,7 @@ public class HavokAsset : MonoBehaviour {
 
 	
 	void GeneratePosRot(string coordinates) {
-		int i = -1;
-
-
+        int i = -1;
 
 		string[] coords = coordinates.Split ('/');
 		//int numcoords = coords.Length;
@@ -215,21 +215,21 @@ public class HavokAsset : MonoBehaviour {
             Matrix4x4 m = new Matrix4x4();
 
 
-			float rz = 	float.Parse (coords [i + 1]) * -1;
-			float ry =	float.Parse (coords [i + 2]) * -1;
-			float rx =	float.Parse (coords [i + 3]) * -1;
+			float rz = 	float.Parse (coords [i + 1], cultureInfo) * -1;
+			float ry =	float.Parse (coords [i + 2], cultureInfo) * -1;
+			float rx =	float.Parse (coords [i + 3], cultureInfo) * -1;
 
-			float uz =	float.Parse (coords [i + 5]);
-			float uy =	float.Parse (coords [i + 6]);
-			float ux =	float.Parse (coords [i + 7]);
+			float uz =	float.Parse (coords [i + 5], cultureInfo);
+			float uy =	float.Parse (coords [i + 6], cultureInfo);
+			float ux =	float.Parse (coords [i + 7], cultureInfo);
 
-			float fz =	float.Parse (coords [i + 9]);
-			float fy =	float.Parse (coords [i + 10]);
-			float fx =	float.Parse (coords [i + 11]);
+			float fz =	float.Parse (coords [i + 9], cultureInfo);
+			float fy =	float.Parse (coords [i + 10], cultureInfo);
+			float fx =	float.Parse (coords [i + 11], cultureInfo);
 
-			float z =	float.Parse (coords [(i + 13)]);
-			float y = 	float.Parse (coords [(i + 14)]);
-			float x = 	float.Parse (coords [(i + 15)]);
+			float z =	float.Parse (coords [(i + 13)], cultureInfo);
+			float y = 	float.Parse (coords [(i + 14)], cultureInfo);
+			float x = 	float.Parse (coords [(i + 15)], cultureInfo);
 
             m.SetColumn(0, new Vector4(rx, ry, rz, 0));
             m.SetColumn(1, new Vector4(ux, uy, uz, 0));

--- a/Assets/Scripts/Utilities/Util.cs
+++ b/Assets/Scripts/Utilities/Util.cs
@@ -32,43 +32,45 @@ public class Util {
     }
 		
 	public static string GetMatrixString(Transform transform) {
-		Vector3 pos = transform.position;
-		Quaternion rot = transform.rotation;
-
-
-		Matrix4x4 matrix = new Matrix4x4(); 
-		matrix.SetTRS(pos.normalized,Normalize(rot),Vector3.one);
-		Matrix4x4 m = matrix;
-
-
-		string m02 = ( m.m02 ).ToString();
-		string m10 = ( m.m10 * -1).ToString();
-		string m00 = ( m.m00 * -1).ToString();
-		string m21 = ( m.m21 ).ToString();
-		string m11 = ( m.m11 ).ToString();
-		string m01 = ( m.m01 ).ToString();
-		string m22 = ( m.m22 ).ToString();
-		string m12 = ( m.m12 ).ToString();
-		string m20 = ( m.m20  * -1).ToString ();
-
-		if( m.m02.ToString() == "1") { 	m02 = "1.0"; } else if(m.m02.ToString() == "-1") { m02 = "-1.0";}
-		if( m.m10.ToString() == "1") { 	m10 = "1.0"; } else if(m.m10.ToString() == "-1") { m10 = "-1.0";}  
-		if( m.m00.ToString() == "1") { 	m00 = "1.0"; } else if(m.m00.ToString() == "-1") { m00 = "-1.0";}  
-		if( m.m21.ToString() == "1") { 	m21 = "1.0"; } else if(m.m21.ToString() == "-1") { m21 = "-1.0";}  
-		if( m.m11.ToString() == "1") { 	m11 = "1.0"; } else if(m.m11.ToString() == "-1") { m11 = "-1.0";}  
-		if( m.m01.ToString() == "1") { 	m01 = "1.0"; } else if(m.m01.ToString() == "-1") { m01 = "-1.0";}  
-		if( m.m22.ToString() == "1") { 	m22 = "1.0"; } else if(m.m22.ToString() == "-1") { m22 = "-1.0";}  
-		if( m.m12.ToString() == "1") { 	m12 = "1.0"; } else if(m.m12.ToString() == "-1") { m12 = "-1.0";}  
-		if( m.m20.ToString() == "1") { 	m20 = "1.0"; } else if(m.m20.ToString() == "-1") { m20 = "-1.0";}  	
-
-
-		string matrixstring =
-			m20+ "/" + m10 + "/" + m00 + "/*zero*/" +
-			m21 + "/" + m11+ "/" + m01+ "/*zero*/" +
-			m22+ "/" + m12+ "/" + m02+ "/*zero*/" +
-			pos.z + "/" + pos.y + "/" + pos.x + "/*zero*";
-
-		return matrixstring;
+        Vector3 pos = transform.position;
+        Quaternion rot = transform.rotation;
+        
+        Matrix4x4 matrix = new Matrix4x4(); 
+        matrix.SetTRS(pos.normalized,Normalize(rot),Vector3.one);
+        Matrix4x4 m = matrix;
+        
+        string posX = pos.x.ToString(cultureInfo),
+               posY = pos.y.ToString(cultureInfo),
+               posZ = pos.z.ToString(cultureInfo);
+        
+        string m02 = ( m.m02 ).ToString(cultureInfo);
+        string m10 = ( m.m10 * -1).ToString(cultureInfo);
+        string m00 = ( m.m00 * -1).ToString(cultureInfo);
+        string m21 = ( m.m21 ).ToString(cultureInfo);
+        string m11 = ( m.m11 ).ToString(cultureInfo);
+        string m01 = ( m.m01 ).ToString(cultureInfo);
+        string m22 = ( m.m22 ).ToString(cultureInfo);
+        string m12 = ( m.m12 ).ToString(cultureInfo);
+        string m20 = ( m.m20  * -1).ToString (cultureInfo);
+        
+        if( m.m02.ToString() == "1") { 	m02 = "1.0"; } else if(m.m02.ToString() == "-1") { m02 = "-1.0";}
+        if( m.m10.ToString() == "1") { 	m10 = "1.0"; } else if(m.m10.ToString() == "-1") { m10 = "-1.0";}  
+        if( m.m00.ToString() == "1") { 	m00 = "1.0"; } else if(m.m00.ToString() == "-1") { m00 = "-1.0";}  
+        if( m.m21.ToString() == "1") { 	m21 = "1.0"; } else if(m.m21.ToString() == "-1") { m21 = "-1.0";}  
+        if( m.m11.ToString() == "1") { 	m11 = "1.0"; } else if(m.m11.ToString() == "-1") { m11 = "-1.0";}  
+        if( m.m01.ToString() == "1") { 	m01 = "1.0"; } else if(m.m01.ToString() == "-1") { m01 = "-1.0";}  
+        if( m.m22.ToString() == "1") { 	m22 = "1.0"; } else if(m.m22.ToString() == "-1") { m22 = "-1.0";}  
+        if( m.m12.ToString() == "1") { 	m12 = "1.0"; } else if(m.m12.ToString() == "-1") { m12 = "-1.0";}  
+        if( m.m20.ToString() == "1") { 	m20 = "1.0"; } else if(m.m20.ToString() == "-1") { m20 = "-1.0";}  	
+        
+        
+        string matrixstring =
+        	m20+ "/" + m10 + "/" + m00 + "/*zero*/" +
+        	m21 + "/" + m11+ "/" + m01+ "/*zero*/" +
+        	m22+ "/" + m12+ "/" + m02+ "/*zero*/" +
+        	posZ + "/" + posY + "/" + posX + "/*zero*";
+        
+        return matrixstring;
 	}
 
 

--- a/Assets/Scripts/Utilities/Util.cs
+++ b/Assets/Scripts/Utilities/Util.cs
@@ -73,10 +73,10 @@ public class Util {
 
 
 	static Quaternion Normalize(Quaternion q){
-        double nqx = double.Parse (q.x.ToString (), cultureInfo);
-		double nqy = double.Parse (q.y.ToString (), cultureInfo);
-		double nqz = double.Parse (q.z.ToString (), cultureInfo);
-		double nqw = double.Parse (q.w.ToString (), cultureInfo);
+        double nqx = double.Parse (q.x.ToString ());
+		double nqy = double.Parse (q.y.ToString ());
+		double nqz = double.Parse (q.z.ToString ());
+		double nqw = double.Parse (q.w.ToString ());
 
 		double norm2 = nqx*nqx + nqy*nqy + nqz*nqz + nqw*nqw;
 		if (norm2 > Double.MaxValue) 
@@ -99,7 +99,7 @@ public class Util {
 		nqz *= normInverse;
 		nqw *= normInverse; 
 
-		Quaternion quat = new Quaternion (float.Parse (nqx.ToString(), cultureInfo), float.Parse (nqy.ToString(), cultureInfo), float.Parse (nqz.ToString(), cultureInfo), float.Parse (nqw.ToString(), cultureInfo));
+		Quaternion quat = new Quaternion (float.Parse (nqx.ToString()), float.Parse (nqy.ToString()), float.Parse (nqz.ToString()), float.Parse (nqw.ToString()));
 		return quat;
 	}
 

--- a/Assets/Scripts/Utilities/Util.cs
+++ b/Assets/Scripts/Utilities/Util.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Globalization;
 using BC2;
 using BC2.Util.Texture;
 
@@ -12,6 +13,7 @@ public class Util {
 
 	public static MapLoad mapLoad;
 	private static Dictionary<string, string> ExistingFiles = new Dictionary<string, string>();
+    private static CultureInfo cultureInfo = new CultureInfo("en-US", false);
 
     public static Inst GetType(string type, Partition partition)
     {
@@ -71,10 +73,10 @@ public class Util {
 
 
 	static Quaternion Normalize(Quaternion q){
-		double nqx = double.Parse (q.x.ToString ());
-		double nqy = double.Parse (q.y.ToString ());
-		double nqz = double.Parse (q.z.ToString ());
-		double nqw = double.Parse (q.w.ToString ());
+        double nqx = double.Parse (q.x.ToString (), cultureInfo);
+		double nqy = double.Parse (q.y.ToString (), cultureInfo);
+		double nqz = double.Parse (q.z.ToString (), cultureInfo);
+		double nqw = double.Parse (q.w.ToString (), cultureInfo);
 
 		double norm2 = nqx*nqx + nqy*nqy + nqz*nqz + nqw*nqw;
 		if (norm2 > Double.MaxValue) 
@@ -97,7 +99,7 @@ public class Util {
 		nqz *= normInverse;
 		nqw *= normInverse; 
 
-		Quaternion quat = new Quaternion (float.Parse (nqx.ToString()), float.Parse (nqy.ToString()), float.Parse (nqz.ToString()), float.Parse (nqw.ToString()));
+		Quaternion quat = new Quaternion (float.Parse (nqx.ToString(), cultureInfo), float.Parse (nqy.ToString(), cultureInfo), float.Parse (nqz.ToString(), cultureInfo), float.Parse (nqw.ToString(), cultureInfo));
 		return quat;
 	}
 
@@ -343,8 +345,8 @@ public class Util {
 	public static Vector3 GetPosition(Inst inst) {
 		Vector3 pos = Vector3.zero;
 		string bc2pos = null;
-		
-		if (Util.GetComplex("Transform", inst) != null || Util.GetComplex("Position", inst) != null) {
+
+        if (Util.GetComplex("Transform", inst) != null || Util.GetComplex("Position", inst) != null) {
             //Util.Log(inst.guid);
             if(Util.GetComplex("Transform", inst) != null && Util.GetComplex("Transform", inst).value != null)
             {
@@ -359,9 +361,9 @@ public class Util {
 				string coordiantes = bc2pos;
 				string[] coords = coordiantes.Split ('/');
 				int numcoords = coords.Length;
-				float z = float.Parse (coords [(numcoords - 4)]);
-				float y = float.Parse (coords [(numcoords - 3)]);
-				float x = float.Parse (coords [(numcoords - 2)]);
+				float z = float.Parse (coords [(numcoords - 4)], cultureInfo);
+				float y = float.Parse (coords [(numcoords - 3)], cultureInfo);
+				float x = float.Parse (coords [(numcoords - 2)], cultureInfo);
 				pos = new Vector3 (x, y, z);
 			}
 			
@@ -378,9 +380,9 @@ public class Util {
 			string coordiantes = bc2pos;
 			string[] coords = coordiantes.Split ('/');
 			int numcoords = coords.Length;
-			float z = float.Parse (coords [(numcoords - 4)]);
-			float y = float.Parse (coords [(numcoords - 3)]);
-			float x = float.Parse (coords [(numcoords - 2)]);
+			float z = float.Parse (coords [(numcoords - 4)], cultureInfo);
+			float y = float.Parse (coords [(numcoords - 3)], cultureInfo);
+			float x = float.Parse (coords [(numcoords - 2)], cultureInfo);
 			pos = new Vector3 (x, y, z);
 		}
 		return pos;
@@ -400,21 +402,21 @@ public class Util {
 			string[] coords = coordiantes.Split ('/');
 			int numcoords = coords.Length;
 			if(numcoords > 3) { 
-				float rz = (float.Parse (coords [0]) * -1);
-				float ry = (float.Parse (coords [1]) * -1);
-				float rx = (float.Parse (coords [2]) * -1);
+				float rz = (float.Parse (coords [0], cultureInfo) * -1);
+				float ry = (float.Parse (coords [1], cultureInfo) * -1);
+				float rx = (float.Parse (coords [2], cultureInfo) * -1);
 				
-				float uz = (float.Parse (coords [4]));
-				float uy = (float.Parse (coords [5]));
-				float ux = (float.Parse (coords [6]));
+				float uz = (float.Parse (coords [4], cultureInfo));
+				float uy = (float.Parse (coords [5], cultureInfo));
+				float ux = (float.Parse (coords [6], cultureInfo));
 				
-				float fz = (float.Parse (coords [8]));
-				float fy = (float.Parse (coords [9]));
-				float fx = (float.Parse (coords [10]));
+				float fz = (float.Parse (coords [8], cultureInfo));
+				float fy = (float.Parse (coords [9], cultureInfo));
+				float fx = (float.Parse (coords [10], cultureInfo));
 				
-				float px = (float.Parse (coords [12]));
-				float py = (float.Parse (coords [13]));
-				float pz = (float.Parse (coords [14]));
+				float px = (float.Parse (coords [12], cultureInfo));
+				float py = (float.Parse (coords [13], cultureInfo));
+				float pz = (float.Parse (coords [14], cultureInfo));
 				
 				matrix.SetColumn(0, new Vector4(rx,ry,rz,0));
 				matrix.SetColumn(1, new Vector4(ux,uy,uz,0));
@@ -432,21 +434,21 @@ public class Util {
 			string[] coords = coordiantes.Split ('/');
 			int numcoords = coords.Length;
 			if(numcoords > 3) { 
-				float rz = (float.Parse (coords [0]) * -1);
-				float ry = (float.Parse (coords [1]) * -1);
-				float rx = (float.Parse (coords [2]) * -1);
+				float rz = (float.Parse (coords [0], cultureInfo) * -1);
+				float ry = (float.Parse (coords [1], cultureInfo) * -1);
+				float rx = (float.Parse (coords [2], cultureInfo) * -1);
+
+				float uz = (float.Parse (coords [4], cultureInfo));
+				float uy = (float.Parse (coords [5], cultureInfo));
+				float ux = (float.Parse (coords [6], cultureInfo));
+
+				float fz = (float.Parse (coords [8], cultureInfo));
+				float fy = (float.Parse (coords [9], cultureInfo));
+				float fx = (float.Parse (coords [10], cultureInfo));
 				
-				float uz = (float.Parse (coords [4]));
-				float uy = (float.Parse (coords [5]));
-				float ux = (float.Parse (coords [6]));
-				
-				float fz = (float.Parse (coords [8]));
-				float fy = (float.Parse (coords [9]));
-				float fx = (float.Parse (coords [10]));
-				
-				float px = (float.Parse (coords [12]));
-				float py = (float.Parse (coords [13]));
-				float pz = (float.Parse (coords [14]));
+				float px = (float.Parse (coords [12], cultureInfo));
+				float py = (float.Parse (coords [13], cultureInfo));
+				float pz = (float.Parse (coords [14], cultureInfo));
 				
 				matrix.SetColumn(0, new Vector4(rx,ry,rz,0));
 				matrix.SetColumn(1, new Vector4(ux,uy,uz,0));


### PR DESCRIPTION
Explicitly use the CultureInfo "en-US" when parsing most of the double and float values to avoid issues with systems that use e.g. a comma as a decimal separator.

See this issue for more info: https://github.com/Powback/Bad-Company-2-Map-Editor/issues/46

Edit: GitHub messed up the code indenting a little bit for whatever reason. 

Edit 2: Just noticed that your code had already issues with the indentation before. This seems to happen when you use spaces instead of tabs or vice versa. Since you have used both for indenting the code of your project, which should I use? Or doesn't it matter because it's only a visual issue on GitHub? In VS2017 and Notepad++ the indenting looks fine. Sorry to bother you with such beginner stuff. I'm not directly new to coding, but it's the first time I contribute to someone else code (on GitHub) so I never had to mess with things like that before.